### PR TITLE
Prep deploy script for renderer tags

### DIFF
--- a/manifest-output.json
+++ b/manifest-output.json
@@ -1,1 +1,0 @@
-{"manifestId":"actDwU1XQiHsIEvXZfuHwBlGAImUUXpvJSWON7xcWME"}

--- a/perma-deploy.mjs
+++ b/perma-deploy.mjs
@@ -1,5 +1,31 @@
+import Bundlr from '@bundlr-network/client';
 import { execSync } from 'child_process';
+import fs from 'fs';
 
+// Deploys files and adds a renderer tags.
+async function deployRenderer(folder) {
+	const jwk = JSON.parse(fs.readFileSync(process.env.PATH_TO_WALLET).toString());
+	const bundlr = new Bundlr.default('http://node2.bundlr.network', 'arweave', jwk);
+
+	const tags = [
+		{ name: 'Implements', value: 'ANS-110' },
+		{ name: 'Type', value: 'renderer' },
+		{ name: 'Title', value: 'The Microscope Renderer' },
+		{ name: 'Description', value: 'ANS-110' },
+		{ name: 'Topic:Renderer', value: 'Renderer' },
+		// { name: 'Render-For', value: '<add value here if the renderer is for a specific ANS-110 type>' },
+	];
+	const uploaded = await bundlr.uploadFolder(folder, {
+		indexFile: 'index.html', // optional index file (file the user will load when accessing the manifest)
+		batchSize: 50, //number of items to upload at once
+		keepDeleted: false, // whether to keep now deleted items from previous uploads
+		manifestTags: [{ tags }],
+	});
+
+	console.log(`Files uploaded. Manifest Id ${uploaded.id}`);
+}
+
+// Deploys files without adding tags
 function deployFiles(folder) {
 	execSync(
 		`npx bundlr upload-dir ${folder} -w ${process.env.PATH_TO_WALLET} --index-file index.html -c arweave -h https://node2.bundlr.network --no-confirmation`,
@@ -17,4 +43,4 @@ if (!folder) {
 	process.exit(1);
 }
 
-deployFiles(folder);
+deployRenderer(folder).catch(console.log);


### PR DESCRIPTION
We can add manifest tags when is PR goes in: https://github.com/Bundlr-Network/js-sdk/pull/82

eg.

```js
const tags = [
		{ name: 'Implements', value: 'ANS-110' },
		{ name: 'Type', value: 'renderer' },
		{ name: 'Title', value: 'The Microscope Renderer' },
		{ name: 'Description', value: 'ANS-110' },
		{ name: 'Topic:Renderer', value: 'Renderer' },
		// { name: 'Render-For', value: '<add value here if the renderer is for a specific ANS-110 type>' },
	];
	const uploaded = await bundlr.uploadFolder(folder, {
		indexFile: 'index.html', // optional index file (file the user will load when accessing the manifest)
		batchSize: 50, //number of items to upload at once
		keepDeleted: false, // whether to keep now deleted items from previous uploads
		manifestTags: [{ tags }],
	});

```